### PR TITLE
Rewrite row config

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -240,3 +240,7 @@
         }
     }
 }
+
+.row{
+    margin: 0px !important;
+}


### PR DESCRIPTION
By default bootstrap class adds the row the following definition: 
```css
.row {
  margin-right: -15px;
  margin-left: -15px;
}
```
What makes some points where margins are necessary, such as in mobile, is along the edges of the device, thus leaving in some ugly spots or hard to read, is an example of how it looks with update.

![Image](http://g.recordit.co/on15DQesT7.gif)